### PR TITLE
Use the correct package name in the installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ PHP client that utilizes Guzzle to interact with the [Shutterstock API](https://
 Use [Composer](https://getcomposer.org/) to install the dependencies.
 
 ```bash
-$ composer require shutterstock/php-shutterstock-api
+$ composer require shutterstock/api
 ```
 
 ## Usage


### PR DESCRIPTION
The installation docs referenced `composer require shutterstock/php-shutterstock-api`, but this is not a valid package name.

Rewording to `composer require shutterstock/api` fixes the issue, as this is the name given in the `composer.json` file.