### PR TITLE
Fix failed Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,21 @@ language: php
 
 php:
   - 5.6
-  - 7
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
 
 install:
   - composer self-update
-  - composer install --dev --no-interaction
+  - composer update --no-interaction
 
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
 
-script: phpunit --tap --coverage-clover build/logs/clover.xml
+script: vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "psr/log": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0"
+        "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -6,9 +6,9 @@ use GuzzleHttp\Client as Guzzle;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Response;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class ClientTest extends PHPUnit_Framework_TestCase
+class ClientTest extends TestCase
 {
 
     use MockClientTrait,

--- a/tests/JsonStreamTest.php
+++ b/tests/JsonStreamTest.php
@@ -3,9 +3,9 @@
 namespace Shutterstock\Api;
 
 use GuzzleHttp\Psr7\Stream;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class JsonStreamTest extends PHPUnit_Framework_TestCase
+class JsonStreamTest extends TestCase
 {
 
     public function testIsInstanceOfJsonStream()


### PR DESCRIPTION
# Changed log
- To fix failed Travis CI build, it should use `vendor/bin/phpunit` version because the default PHPUnit build version is not correct for `php-7.x` versions.
- To be compatible with multiple `php-7.x` versions, it should define multiple PHPUnit versions for different PHP versions.
- To support latest stable PHPUnit version, using the `PHPUnit\Framework\TestCase` namespace.

@jacobemerick, please look at this PR, thanks.